### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,12 +1,13 @@
-# OpenSearch Perftop Maintainers
+## Overview
 
-## Maintainers
-| Maintainer              | GitHub ID                                               | Affiliation |
-| ----------------------- | ------------------------------------------------------- | ----------- |
-| Joshua Tokle            | [jotok](https://github.com/jotok)                       | Amazon      |
-| Kunal Khatua            | [kkhatua](https://github.com/kkhatua)                   | Amazon      |
-| Ruizhen Guo             | [rguo-aws](https://github.com/rguo-aws)                 | Amazon      |
-| Sruti Parthiban         | [sruti1312](https://github.com/sruti1312)               | Amazon      |
-| Yujia Sun               | [yujias0706](https://github.com/yujias0706)             | Amazon      |
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
 
-[This document](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md) explains what maintainers do in this repo, and how they should be doing it. If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+## Current Maintainers
+
+| Maintainer      | GitHub ID                                   | Affiliation |
+| --------------- | ------------------------------------------- | ----------- |
+| Joshua Tokle    | [jotok](https://github.com/jotok)           | Amazon      |
+| Kunal Khatua    | [kkhatua](https://github.com/kkhatua)       | Amazon      |
+| Ruizhen Guo     | [rguo-aws](https://github.com/rguo-aws)     | Amazon      |
+| Sruti Parthiban | [sruti1312](https://github.com/sruti1312)   | Amazon      |
+| Yujia Sun       | [yujias0706](https://github.com/yujias0706) | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.